### PR TITLE
Update README filename in make scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,4 +43,4 @@ AUX_DIST = $(ac_aux_dir)/config.guess \
 
 # Documentation files that should be both distributed and installed in the doc
 # directory,
-dist_doc_DATA = README.txt license.txt
+dist_doc_DATA = README.md license.txt

--- a/Makefile.in
+++ b/Makefile.in
@@ -240,7 +240,7 @@ AUX_DIST = $(ac_aux_dir)/config.guess \
 
 # Documentation files that should be both distributed and installed in the doc
 # directory,
-dist_doc_DATA = README.txt license.txt
+dist_doc_DATA = README.md license.txt
 all: all-am
 
 .SUFFIXES:


### PR DESCRIPTION
Change name from README.txt to README.md, following change in 48671c0353bdb31c1058424bcdf1c5b2701f31f2.