### PR TITLE
Update Makefile.am, but see a lot of other reverted or possible useful changes to incorporate from h3xx.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,4 +43,4 @@ AUX_DIST = $(ac_aux_dir)/config.guess \
 
 # Documentation files that should be both distributed and installed in the doc
 # directory,
-dist_doc_DATA = README.txt license.txt
+dist_doc_DATA = README.md license.txt


### PR DESCRIPTION
Update readme dependency to the existing name so build process may succeed.

Actually found #1 now, with `9e44200027078b876064cf9556086d1a538aff61`, and the rest of the  `h3xx`/`portsmf` repository, but I see it was reverted by `c158cb9fd1574f61697b6ce1670843070655e00f`.

So that, and possibly more of the updates there, are being lost here, and should also be fixed too.