### PR TITLE
Fix compile warnings

### DIFF
--- a/allegro.cpp
+++ b/allegro.cpp
@@ -3451,7 +3451,7 @@ void Alg_seq::beat_to_measure(double beat, int *measure, double *m_beat,
             prev_den = time_sig[tsx].den;
         } else {
             m = m + (beat - prev_beat) / bpm;
-            *measure = static_cast<int>(m);
+            *measure = (int)(m);
             *m_beat = (m - *measure) * bpm;
             *num = prev_num;
             *den = prev_den;
@@ -3466,7 +3466,7 @@ void Alg_seq::beat_to_measure(double beat, int *measure, double *m_beat,
     }
     bpm = prev.num * 4 / prev.den;
     m = m + (beat - prev.beat) / bpm;
-    *measure = static_cast<int>(m);
+    *measure = (int)(m);
     *m_beat = (m - *measure) * bpm;
     *num = prev.num;
     *den = prev.den;

--- a/allegro.cpp
+++ b/allegro.cpp
@@ -3451,7 +3451,7 @@ void Alg_seq::beat_to_measure(double beat, int *measure, double *m_beat,
             prev_den = time_sig[tsx].den;
         } else {
             m = m + (beat - prev_beat) / bpm;
-            *measure = m;
+            *measure = static_cast<int>(m);
             *m_beat = (m - *measure) * bpm;
             *num = prev_num;
             *den = prev_den;
@@ -3466,7 +3466,7 @@ void Alg_seq::beat_to_measure(double beat, int *measure, double *m_beat,
     }
     bpm = prev.num * 4 / prev.den;
     m = m + (beat - prev.beat) / bpm;
-    *measure = m;
+    *measure = static_cast<int>(m);
     *m_beat = (m - *measure) * bpm;
     *num = prev.num;
     *den = prev.den;

--- a/allegro.h
+++ b/allegro.h
@@ -580,11 +580,14 @@ public:
     double get_double() { assert(!(((intptr_t) ptr) & 7));
                           double d = *((double *) ptr); ptr += sizeof(double); 
                           return d; }
-    const char *get_string() { char *s = ptr; char *fence = buffer + len;
-                         assert(ptr < fence);
-                         while (*ptr++) assert(ptr < fence);
-                         get_pad();
-                         return s; }
+    const char *get_string() {
+        char *s = ptr;
+        [[maybe_unused]] char *fence = buffer + len;
+        assert(ptr < fence);
+        while (*ptr++) { assert(ptr < fence); }
+        get_pad();
+        return s;
+    }
     void check_input_buffer(int needed) {
         assert(get_posn() + needed <= len); }
 } *Serial_read_buffer_ptr;
@@ -609,7 +612,7 @@ typedef class Serial_write_buffer: public Serial_buffer {
     }
     bool check_buffer(int needed);
     void set_string(const char *s) { 
-        char *fence = buffer + len;
+        [[maybe_unused]] char *fence = buffer + len;
         assert(ptr < fence);
         // two brackets surpress a g++ warning, because this is an
         // assignment operator inside a test.
@@ -682,7 +685,9 @@ public:
     Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, 
               bool units_are_seconds);
     virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
-        if (time_map) time_map->dereference(); time_map = NULL; }
+        if (time_map) { time_map->dereference(); }
+        time_map = NULL;
+    }
 
     // Returns a buffer containing a serialization of the
     // file.  It will be an ASCII representation unless text is true.

--- a/allegro.h
+++ b/allegro.h
@@ -585,7 +585,9 @@ public:
 #ifndef NDEBUG
         const char *fence = buffer + len;
         assert(ptr < fence);
-        while (*ptr++) { assert(ptr < fence); }
+        while (*ptr++) {
+            assert(ptr < fence);
+        }
 #endif
         get_pad();
         return s;

--- a/allegro.h
+++ b/allegro.h
@@ -588,6 +588,8 @@ public:
         while (*ptr++) {
             assert(ptr < fence);
         }
+#else
+        while (*ptr++) {}
 #endif
         get_pad();
         return s;
@@ -633,6 +635,8 @@ typedef class Serial_write_buffer: public Serial_buffer {
 #if defined(_WIN32)
 #pragma warning(default: 4311 4312)
 #endif
+#else
+        while ((*ptr++ = *s++)) {}
 #endif
         pad();
     }

--- a/allegro.h
+++ b/allegro.h
@@ -696,8 +696,8 @@ public:
     virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
         if (time_map) {
             time_map->dereference();
+            time_map = NULL;
         }
-        time_map = NULL;
     }
 
     // Returns a buffer containing a serialization of the

--- a/allegro.h
+++ b/allegro.h
@@ -582,9 +582,10 @@ public:
                           return d; }
     const char *get_string() {
         char *s = ptr;
-        [[maybe_unused]] char *fence = buffer + len;
+        char *fence = buffer + len;
         assert(ptr < fence);
         while (*ptr++) { assert(ptr < fence); }
+        (void)fence;
         get_pad();
         return s;
     }
@@ -612,11 +613,11 @@ typedef class Serial_write_buffer: public Serial_buffer {
     }
     bool check_buffer(int needed);
     void set_string(const char *s) { 
-        [[maybe_unused]] char *fence = buffer + len;
+        char *fence = buffer + len;
         assert(ptr < fence);
         // two brackets surpress a g++ warning, because this is an
         // assignment operator inside a test.
-        while ((*ptr++ = *s++)) assert(ptr < fence);
+        while ((*ptr++ = *s++)) { assert(ptr < fence); }
         // 4311 is type cast pointer to long warning
         // 4312 is type cast long to pointer warning
 #if defined(_WIN32)
@@ -626,7 +627,9 @@ typedef class Serial_write_buffer: public Serial_buffer {
 #if defined(_WIN32)
 #pragma warning(default: 4311 4312)
 #endif
-        pad(); }
+        (void)fence;
+        pad();
+    }
     void set_int32(int v) { *((int32 *) ptr) = (int32) v; ptr += 4; }
     void set_int64(int64 v) { assert(!(((intptr_t) ptr) & 7));
                               *((int64 *) ptr) = (int64) v; ptr += 8; }

--- a/allegro.h
+++ b/allegro.h
@@ -582,10 +582,11 @@ public:
                           return d; }
     const char *get_string() {
         char *s = ptr;
-        char *fence = buffer + len;
+#ifndef NDEBUG
+        const char *fence = buffer + len;
         assert(ptr < fence);
         while (*ptr++) { assert(ptr < fence); }
-        (void)fence;
+#endif
         get_pad();
         return s;
     }
@@ -613,11 +614,14 @@ typedef class Serial_write_buffer: public Serial_buffer {
     }
     bool check_buffer(int needed);
     void set_string(const char *s) { 
-        char *fence = buffer + len;
+#ifndef NDEBUG
+        const char *fence = buffer + len;
         assert(ptr < fence);
         // two brackets surpress a g++ warning, because this is an
         // assignment operator inside a test.
-        while ((*ptr++ = *s++)) { assert(ptr < fence); }
+        while ((*ptr++ = *s++)) {
+            assert(ptr < fence);
+        }
         // 4311 is type cast pointer to long warning
         // 4312 is type cast long to pointer warning
 #if defined(_WIN32)
@@ -627,7 +631,7 @@ typedef class Serial_write_buffer: public Serial_buffer {
 #if defined(_WIN32)
 #pragma warning(default: 4311 4312)
 #endif
-        (void)fence;
+#endif
         pad();
     }
     void set_int32(int v) { *((int32 *) ptr) = (int32) v; ptr += 4; }
@@ -688,7 +692,9 @@ public:
     Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, 
               bool units_are_seconds);
     virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
-        if (time_map) { time_map->dereference(); }
+        if (time_map) {
+            time_map->dereference();
+        }
         time_map = NULL;
     }
 

--- a/allegrord.cpp
+++ b/allegrord.cpp
@@ -631,7 +631,7 @@ double Alg_reader::parse_loud(string &field)
 {
     const char *msg = "Loudness expected";
     if (isdigit(field[1])) {
-        return parse_int(field);
+        return static_cast<double>(parse_int(field));
     } else {
         string dyn = field.substr(1);
         transform(dyn.begin(), dyn.end(), dyn.begin(), ::toupper);

--- a/allegrord.cpp
+++ b/allegrord.cpp
@@ -631,7 +631,7 @@ double Alg_reader::parse_loud(string &field)
 {
     const char *msg = "Loudness expected";
     if (isdigit(field[1])) {
-        return static_cast<double>(parse_int(field));
+        return (double)(parse_int(field));
     } else {
         string dyn = field.substr(1);
         transform(dyn.begin(), dyn.end(), dyn.begin(), ::toupper);


### PR DESCRIPTION
This resolves some warnings for those of us that use `-Werror`.

- `unused-variable` @ `allegro.h:612`, `allegro.h:583`
  * Fixed by putting debug stuff inside an `#ifndef NDEBUG`
- `misleading-indentation` @ `allegro.h:685`
  * Fixed by adding curly brackets around if statement body to remove any ambiguity
- `C4244 conversion from 'double' to 'int'` @ `allegro.cpp:3454`, `allegro.cpp:3469`
  * Fixed with explicit `(int)` cast
- `C4244 conversion from 'int64' to 'double'` @ `allegrord.cpp:634`
  * Fixed with explicit `(double)` cast